### PR TITLE
Fix config generator docstring

### DIFF
--- a/generate-config.py
+++ b/generate-config.py
@@ -3,13 +3,13 @@
 Configuration Generator for Markdown Converter Toolkit
 
 Creates a default configuration file with user-friendly comments.
-Run this script to generate .markdown-converter.json in your current directory.
+Run this script to generate markdown-converter.json in your current directory.
 """
 import json
 import os
 from markdown_utils import get_default_config
 
-def generate_config_file(filepath=".markdown-converter.json"):
+def generate_config_file(filepath="markdown-converter.json"):
     """Generate a configuration file with default settings and comments."""
     
     config = get_default_config()


### PR DESCRIPTION
## Summary
- correct config generator docstring
- update default config path to use visible file

## Testing
- `python3 -m py_compile generate-config.py`


------
https://chatgpt.com/codex/tasks/task_e_683aa13aad508327b725053d70b18925