### PR TITLE
Fix duplicate markdown prompt

### DIFF
--- a/MarkdownConverter.py
+++ b/MarkdownConverter.py
@@ -47,11 +47,13 @@ def get_user_choice():
 
 def get_markdown_input_with_prompt():
     """Get Markdown text from user input with custom prompt."""
-    print("\nEnter/paste your Markdown text.")
-    print("Finish with Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows):")
-    print("-" * 60)
-    
-    return get_markdown_input()
+    prompt = (
+        "\nEnter/paste your Markdown text.\n"
+        "Finish with Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows):\n"
+        + "-" * 60 + "\n"
+    )
+
+    return get_markdown_input(prompt)
 
 def convert_to_pdf(markdown_text, config=None):
     """Convert Markdown to PDF."""

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -38,14 +38,17 @@ def check_pdflatex():
     return shutil.which('pdflatex') is not None
 
 
-def get_markdown_input():
+def get_markdown_input(prompt=None):
     """Get Markdown text from user input via stdin."""
-    prompt = (
-        "Enter/paste your Markdown text.\n"
-        "Finish with Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows):\n"
-    )
-    sys.stdout.write(prompt)
-    sys.stdout.flush()
+    if prompt is None:
+        prompt = (
+            "Enter/paste your Markdown text.\n"
+            "Finish with Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows):\n"
+        )
+
+    if prompt:
+        sys.stdout.write(prompt)
+        sys.stdout.flush()
     
     try:
         markdown_text = sys.stdin.read()


### PR DESCRIPTION
## Summary
- make get_markdown_input accept an optional prompt
- call get_markdown_input with custom prompt in MarkdownConverter

## Testing
- `python3 -m py_compile MarkdownConverter.py markdown_utils.py legacy/MarkdownToPDF/MarkdownToPDF.py legacy/MarkdownToWord/MarkdownToWord.py legacy/MarkdownToLatex/MarkdownToLatex.py`

------
https://chatgpt.com/codex/tasks/task_e_683aa130af4c832782a1a778d1b222bc