### PR TITLE
Add auto-open output feature

### DIFF
--- a/MarkdownConverter.py
+++ b/MarkdownConverter.py
@@ -14,7 +14,7 @@ from markdown_utils import (
     get_unique_filename, check_pandoc, check_pdflatex, 
     get_markdown_input, ensure_output_dir, get_dated_filename, 
     run_pandoc, run_pdflatex, save_markdown_file,
-    load_config, build_pandoc_args
+    load_config, build_pandoc_args, open_file
 )
 
 def check_dependencies():
@@ -76,6 +76,9 @@ def convert_to_pdf(markdown_text, config=None):
         if md_file:
             print(f"📝 Markdown saved: {md_file}")
     
+    if config['global'].get('auto_open_output'):
+        open_file(output_pdf)
+
     return output_pdf
 
 def convert_to_word(markdown_text, config=None):
@@ -99,6 +102,9 @@ def convert_to_word(markdown_text, config=None):
         if md_file:
             print(f"📝 Markdown saved: {md_file}")
     
+    if config['global'].get('auto_open_output'):
+        open_file(output_docx)
+
     return output_docx
 
 def convert_to_latex(markdown_text, has_pdflatex, config=None):
@@ -131,18 +137,26 @@ def convert_to_latex(markdown_text, has_pdflatex, config=None):
         success, pdf_file = run_pdflatex(output_tex, output_dir)
         if success:
             print(f"✅ PDF created: {pdf_file}")
+            if config['global'].get('auto_open_output'):
+                open_file(pdf_file)
             return output_tex, pdf_file
         else:
             print(f"⚠️  Warning: pdflatex failed.")
             print(f"LaTeX file created successfully: {output_tex}")
+            if config['global'].get('auto_open_output'):
+                open_file(output_tex)
             return output_tex, None
     elif not has_pdflatex:
         print("⚠️  Warning: pdflatex not found; skipping PDF compilation.")
         print(f"LaTeX file created successfully: {output_tex}")
+        if config['global'].get('auto_open_output'):
+            open_file(output_tex)
         return output_tex, None
     else:
         print("ℹ️  PDF compilation disabled in configuration.")
         print(f"LaTeX file created successfully: {output_tex}")
+        if config['global'].get('auto_open_output'):
+            open_file(output_tex)
         return output_tex, None
 
 def main():

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A streamlined toolkit for converting Markdown to PDF, Word (DOCX), and LaTeX for
 - **Anti-overwrite protection** with automatic file naming
 - **macOS desktop integration** via .app bundles
 - **No external Python dependencies** - uses only standard library + pandoc/pdflatex
+- **Optional auto-open** to launch converted files automatically
 
 ## 🆕 Unified Converter (Recommended)
 
@@ -94,8 +95,14 @@ python3 -c "from markdown_utils import check_pandoc; check_pandoc(); print('✅ 
 
 All tools create organized output folders:
 - **PDF/**: PDF files with date-based naming (e.g., `20250525.pdf`, `20250525-1.pdf`)
-- **DOCX/**: Word documents 
+- **DOCX/**: Word documents
 - **LaTeX/**: LaTeX source files and compiled PDFs
+
+### Auto-Open Output
+
+Set `"auto_open_output": true` in `markdown-converter.json` to automatically
+open each converted file with your system's default viewer. Generate a sample
+config with `generate-config.py` if needed.
 
 ## 🔍 For Developers
 

--- a/README_UNIFIED.md
+++ b/README_UNIFIED.md
@@ -10,6 +10,7 @@ A single, interactive interface for converting Markdown to PDF, Word (DOCX), or 
 - **Date-based Naming**: Output files use YYYYMMDD format with anti-overwrite protection
 - **Dependency Checking**: Automatically detects required tools (Pandoc, pdflatex)
 - **Continuous Operation**: Convert multiple files in a single session
+- **Optional Auto-Open**: Automatically open converted files when enabled in the configuration
 
 ## Prerequisites
 
@@ -94,6 +95,11 @@ The tool automatically creates and organizes files into format-specific folders:
 - **Word files**: `DOCX/20250525.docx`, `DOCX/20250525-1.docx`, etc.
 - **LaTeX files**: `LaTeX/20250525.tex`, `LaTeX/20250525.pdf`, etc.
   - Includes compiled PDF and auxiliary files (.aux, .log)
+
+### Auto-Open Output
+
+Set `"auto_open_output": true` in your configuration file to launch each
+converted file automatically with the system's default application.
 
 ## Conversion Options
 

--- a/generate-config.py
+++ b/generate-config.py
@@ -24,7 +24,7 @@ def generate_config_file(filepath="markdown-converter.json"):
             "save_markdown_source": config["global"]["save_markdown_source"],
             "_save_markdown_source_comment": "Save input markdown as .md file alongside converted output",
             "auto_open_output": config["global"]["auto_open_output"],
-            "_auto_open_output_comment": "Automatically open converted files (not implemented yet)",
+            "_auto_open_output_comment": "Automatically open converted files after conversion",
             "output_naming": config["global"]["output_naming"],
             "_output_naming_comment": "Naming scheme: 'date' (YYYYMMDD), 'prompt' (ask user), 'custom' (not implemented)"
         },

--- a/legacy/MarkdownToLatex/MarkdownToLatex.py
+++ b/legacy/MarkdownToLatex/MarkdownToLatex.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, check_pdflatex, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, run_pdflatex, save_markdown_file,
-    load_config, build_pandoc_args
+    load_config, build_pandoc_args, open_file
 )
 
 def main():
@@ -43,7 +43,7 @@ def main():
             print(f"Markdown saved: {md_file}")
     
     print(f"LaTeX created: {output_tex}")
-    
+
     # Check if PDF compilation should be attempted
     has_pdflatex = check_pdflatex()
     should_compile = config['latex'].get('compile_pdf', True) and has_pdflatex
@@ -52,12 +52,20 @@ def main():
         success, pdf_file = run_pdflatex(output_tex, output_dir)
         if success:
             print(f"PDF created: {pdf_file}")
+            if config['global'].get('auto_open_output'):
+                open_file(pdf_file)
         else:
+            if config['global'].get('auto_open_output'):
+                open_file(output_tex)
             sys.exit(f"Error: pdflatex failed.")
     elif not has_pdflatex:
         print("Warning: pdflatex not found; skipping PDF compilation.")
+        if config['global'].get('auto_open_output'):
+            open_file(output_tex)
     else:
         print("Info: PDF compilation disabled in configuration.")
+        if config['global'].get('auto_open_output'):
+            open_file(output_tex)
 
 if __name__ == '__main__':
     main()

--- a/legacy/MarkdownToPDF/MarkdownToPDF.py
+++ b/legacy/MarkdownToPDF/MarkdownToPDF.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, save_markdown_file,
-    load_config, build_pandoc_args
+    load_config, build_pandoc_args, open_file
 )
 
 def main():
@@ -43,6 +43,8 @@ def main():
             print(f"Markdown saved: {md_file}")
     
     print(f"PDF created: {output_pdf}")
+    if config['global'].get('auto_open_output'):
+        open_file(output_pdf)
 
 if __name__ == '__main__':
     main()

--- a/legacy/MarkdownToWord/MarkdownToWord.py
+++ b/legacy/MarkdownToWord/MarkdownToWord.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, save_markdown_file,
-    load_config, build_pandoc_args
+    load_config, build_pandoc_args, open_file
 )
 
 def main():
@@ -43,6 +43,8 @@ def main():
             print(f"Markdown saved: {md_file}")
     
     print(f"DOCX created: {output_docx}")
+    if config['global'].get('auto_open_output'):
+        open_file(output_docx)
 
 if __name__ == '__main__':
     main()

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -152,6 +152,19 @@ def run_pdflatex(tex_file, output_dir):
         return False, None
 
 
+def open_file(path):
+    """Open a file using the default application for the current OS."""
+    try:
+        if sys.platform.startswith('darwin'):
+            subprocess.run(['open', path], check=False)
+        elif os.name == 'nt':
+            os.startfile(path)  # type: ignore[attr-defined]
+        else:
+            subprocess.run(['xdg-open', path], check=False)
+    except Exception:
+        pass
+
+
 def get_default_config():
     """Return default configuration settings."""
     return {


### PR DESCRIPTION
## Summary
- implement `open_file()` helper for cross-platform file launching
- add automatic opening of converted files controlled by `auto_open_output` config
- update configuration generator comment
- document new behaviour in README files
- update legacy converters with auto-open support

## Testing
- `python3 -m py_compile MarkdownConverter.py markdown_utils.py generate-config.py legacy/MarkdownToPDF/MarkdownToPDF.py legacy/MarkdownToWord/MarkdownToWord.py legacy/MarkdownToLatex/MarkdownToLatex.py`


------
https://chatgpt.com/codex/tasks/task_e_683aacfd295083279988cedbcbddccf9