### PR TITLE
Fix macOS auto-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A streamlined toolkit for converting Markdown to PDF, Word (DOCX), and LaTeX for
 - **Anti-overwrite protection** with automatic file naming
 - **macOS desktop integration** via .app bundles
 - **No external Python dependencies** - uses only standard library + pandoc/pdflatex
-- **Optional auto-open** to launch converted files automatically
+- **Optional auto-open** (macOS, unified converter only) launches PDFs in Preview and DOCX in
+  Microsoft Word
 
 ## 🆕 Unified Converter (Recommended)
 
@@ -101,8 +102,9 @@ All tools create organized output folders:
 ### Auto-Open Output
 
 Set `"auto_open_output": true` in `markdown-converter.json` to automatically
-open each converted file with your system's default viewer. Generate a sample
-config with `generate-config.py` if needed.
+open each converted file when using **MarkdownConverter.py**. On **macOS**, the
+tool launches PDFs in **Preview** and DOCX files in **Microsoft Word**.
+Generate a sample config with `generate-config.py` if needed.
 
 ## 🔍 For Developers
 

--- a/README_UNIFIED.md
+++ b/README_UNIFIED.md
@@ -10,7 +10,7 @@ A single, interactive interface for converting Markdown to PDF, Word (DOCX), or 
 - **Date-based Naming**: Output files use YYYYMMDD format with anti-overwrite protection
 - **Dependency Checking**: Automatically detects required tools (Pandoc, pdflatex)
 - **Continuous Operation**: Convert multiple files in a single session
-- **Optional Auto-Open**: Automatically open converted files when enabled in the configuration
+- **Optional Auto-Open** (macOS): Automatically open PDFs in Preview and DOCX files in Microsoft Word (enabled when using this unified converter)
 
 ## Prerequisites
 
@@ -99,7 +99,8 @@ The tool automatically creates and organizes files into format-specific folders:
 ### Auto-Open Output
 
 Set `"auto_open_output": true` in your configuration file to launch each
-converted file automatically with the system's default application.
+converted file automatically when using this tool. On **macOS**, PDFs open in
+**Preview** and DOCX files open in **Microsoft Word**.
 
 ## Conversion Options
 

--- a/legacy/MarkdownToLatex/MarkdownToLatex.py
+++ b/legacy/MarkdownToLatex/MarkdownToLatex.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, check_pdflatex, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, run_pdflatex, save_markdown_file,
-    load_config, build_pandoc_args, open_file
+    load_config, build_pandoc_args
 )
 
 def main():
@@ -52,20 +52,12 @@ def main():
         success, pdf_file = run_pdflatex(output_tex, output_dir)
         if success:
             print(f"PDF created: {pdf_file}")
-            if config['global'].get('auto_open_output'):
-                open_file(pdf_file)
         else:
-            if config['global'].get('auto_open_output'):
-                open_file(output_tex)
             sys.exit(f"Error: pdflatex failed.")
     elif not has_pdflatex:
         print("Warning: pdflatex not found; skipping PDF compilation.")
-        if config['global'].get('auto_open_output'):
-            open_file(output_tex)
     else:
         print("Info: PDF compilation disabled in configuration.")
-        if config['global'].get('auto_open_output'):
-            open_file(output_tex)
 
 if __name__ == '__main__':
     main()

--- a/legacy/MarkdownToPDF/MarkdownToPDF.py
+++ b/legacy/MarkdownToPDF/MarkdownToPDF.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, save_markdown_file,
-    load_config, build_pandoc_args, open_file
+    load_config, build_pandoc_args
 )
 
 def main():
@@ -43,8 +43,6 @@ def main():
             print(f"Markdown saved: {md_file}")
     
     print(f"PDF created: {output_pdf}")
-    if config['global'].get('auto_open_output'):
-        open_file(output_pdf)
 
 if __name__ == '__main__':
     main()

--- a/legacy/MarkdownToWord/MarkdownToWord.py
+++ b/legacy/MarkdownToWord/MarkdownToWord.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from markdown_utils import (
     check_pandoc, get_markdown_input, ensure_output_dir, 
     get_dated_filename, run_pandoc, save_markdown_file,
-    load_config, build_pandoc_args, open_file
+    load_config, build_pandoc_args
 )
 
 def main():
@@ -43,8 +43,6 @@ def main():
             print(f"Markdown saved: {md_file}")
     
     print(f"DOCX created: {output_docx}")
-    if config['global'].get('auto_open_output'):
-        open_file(output_docx)
 
 if __name__ == '__main__':
     main()

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -155,12 +155,19 @@ def run_pdflatex(tex_file, output_dir):
 def open_file(path):
     """Open a file using the default application for the current OS."""
     try:
+        abs_path = os.path.abspath(path)
         if sys.platform.startswith('darwin'):
-            subprocess.run(['open', path], check=False)
+            ext = os.path.splitext(abs_path)[1].lower()
+            if ext == '.pdf':
+                subprocess.run(['open', '-a', 'Preview', abs_path], check=False)
+            elif ext == '.docx':
+                subprocess.run(['open', '-a', 'Microsoft Word', abs_path], check=False)
+            else:
+                subprocess.run(['open', abs_path], check=False)
         elif os.name == 'nt':
-            os.startfile(path)  # type: ignore[attr-defined]
+            os.startfile(abs_path)  # type: ignore[attr-defined]
         else:
-            subprocess.run(['xdg-open', path], check=False)
+            subprocess.run(['xdg-open', abs_path], check=False)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- open converted files in macOS using Preview or Microsoft Word
- document macOS-only auto-open behavior
- remove auto-open from legacy tools so only the unified converter opens files automatically

## Testing
- `python3 -m py_compile markdown_utils.py MarkdownConverter.py legacy/MarkdownToPDF/MarkdownToPDF.py legacy/MarkdownToWord/MarkdownToWord.py legacy/MarkdownToLatex/MarkdownToLatex.py generate-config.py`

------
https://chatgpt.com/codex/tasks/task_e_683ab91b49888327984dcd16cca0ac24