### PR TITLE
Add auto_open_output setting to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ A streamlined toolkit for converting Markdown to PDF, Word (DOCX), and LaTeX for
 - **Anti-overwrite protection** with automatic file naming
 - **macOS desktop integration** via .app bundles
 - **No external Python dependencies** - uses only standard library + pandoc/pdflatex
-- **Optional auto-open** (macOS, unified converter only) launches PDFs in Preview and DOCX in
-  Microsoft Word
+- **Auto-open**: Converted files open automatically after conversion. On macOS,
+  PDFs open in Preview and DOCX in Microsoft Word. Set `"auto_open_output": false`
+  to disable.
 
 ## 🆕 Unified Converter (Recommended)
 
@@ -101,10 +102,11 @@ All tools create organized output folders:
 
 ### Auto-Open Output
 
-Set `"auto_open_output": true` in `markdown-converter.json` to automatically
-open each converted file when using **MarkdownConverter.py**. On **macOS**, the
-tool launches PDFs in **Preview** and DOCX files in **Microsoft Word**.
-Generate a sample config with `generate-config.py` if needed.
+Output files open automatically after conversion. Set
+`"auto_open_output": false` in `markdown-converter.json` to disable this
+behavior. On **macOS**, the tool launches PDFs in **Preview** and DOCX files in
+**Microsoft Word**. Generate a sample config with `generate-config.py` if
+needed.
 
 ## 🔍 For Developers
 

--- a/README_UNIFIED.md
+++ b/README_UNIFIED.md
@@ -10,7 +10,7 @@ A single, interactive interface for converting Markdown to PDF, Word (DOCX), or 
 - **Date-based Naming**: Output files use YYYYMMDD format with anti-overwrite protection
 - **Dependency Checking**: Automatically detects required tools (Pandoc, pdflatex)
 - **Continuous Operation**: Convert multiple files in a single session
-- **Optional Auto-Open** (macOS): Automatically open PDFs in Preview and DOCX files in Microsoft Word (enabled when using this unified converter)
+- **Auto-Open**: Converted files open automatically after conversion. On macOS, PDFs open in Preview and DOCX files open in Microsoft Word. Set `"auto_open_output": false` to disable.
 
 ## Prerequisites
 
@@ -98,9 +98,10 @@ The tool automatically creates and organizes files into format-specific folders:
 
 ### Auto-Open Output
 
-Set `"auto_open_output": true` in your configuration file to launch each
-converted file automatically when using this tool. On **macOS**, PDFs open in
-**Preview** and DOCX files open in **Microsoft Word**.
+Converted files open automatically after conversion. Set
+`"auto_open_output": false` in your configuration file to disable this
+behavior. On **macOS**, PDFs open in **Preview** and DOCX files open in
+**Microsoft Word**.
 
 ## Conversion Options
 

--- a/generate-config.py
+++ b/generate-config.py
@@ -24,7 +24,7 @@ def generate_config_file(filepath="markdown-converter.json"):
             "save_markdown_source": config["global"]["save_markdown_source"],
             "_save_markdown_source_comment": "Save input markdown as .md file alongside converted output",
             "auto_open_output": config["global"]["auto_open_output"],
-            "_auto_open_output_comment": "Automatically open converted files after conversion",
+            "_auto_open_output_comment": "Automatically open converted files after conversion (set to false to disable)",
             "output_naming": config["global"]["output_naming"],
             "_output_naming_comment": "Naming scheme: 'date' (YYYYMMDD), 'prompt' (ask user), 'custom' (not implemented)"
         },

--- a/markdown-converter.json
+++ b/markdown-converter.json
@@ -1,6 +1,7 @@
 {
   "global": {
-    "save_markdown_source": true
+    "save_markdown_source": true,
+    "auto_open_output": true
   },
   "pdf": {
     "geometry": {

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -177,7 +177,7 @@ def get_default_config():
     return {
         "global": {
             "save_markdown_source": True,
-            "auto_open_output": False,
+            "auto_open_output": True,
             "output_naming": "date"
         },
         "pdf": {


### PR DESCRIPTION
## Summary
- add `auto_open_output` key under `global` settings in `markdown-converter.json`
- update docs to reflect auto-open enabled by default
- update default config in `markdown_utils.py`

## Testing
- `python3 -m py_compile MarkdownConverter.py markdown_utils.py generate-config.py`


------
https://chatgpt.com/codex/tasks/task_e_683ac35419f08327b044dbe21de40883