### PR TITLE
Enhance filename generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Core functions used by all tools:
 #### File Management:
 - `get_unique_filename()`: Anti-overwrite protection with incremental suffixes
 - `ensure_output_dir()`: Creates output directories (PDF/, DOCX/, LaTeX/)
-- `get_dated_filename()`: YYYYMMDD-based naming with uniqueness
+- `get_dated_filename()`: Date + first six words in CamelCase with uniqueness
 
 #### Dependency Management:
 - `check_pandoc()`: Validates pandoc availability, exits if missing

--- a/MarkdownConverter.py
+++ b/MarkdownConverter.py
@@ -62,7 +62,7 @@ def convert_to_pdf(markdown_text, config=None):
     
     output_dir = 'PDF'
     ensure_output_dir(output_dir)
-    output_pdf = get_dated_filename(output_dir, 'pdf')
+    output_pdf = get_dated_filename(output_dir, 'pdf', markdown_text)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-o', output_pdf]
@@ -88,7 +88,7 @@ def convert_to_word(markdown_text, config=None):
     
     output_dir = 'DOCX'
     ensure_output_dir(output_dir)
-    output_docx = get_dated_filename(output_dir, 'docx')
+    output_docx = get_dated_filename(output_dir, 'docx', markdown_text)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-t', 'docx', '-o', output_docx]
@@ -114,7 +114,7 @@ def convert_to_latex(markdown_text, has_pdflatex, config=None):
     
     output_dir = 'LaTeX'
     ensure_output_dir(output_dir)
-    output_tex = get_dated_filename(output_dir, 'tex')
+    output_tex = get_dated_filename(output_dir, 'tex', markdown_text)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-s', '-f', 'markdown', '-t', 'latex', '-o', output_tex]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A streamlined toolkit for converting Markdown to PDF, Word (DOCX), and LaTeX for
 **MarkdownConverter.py** - Interactive tool for all conversions:
 - Interactive menu to choose output format (PDF, Word, LaTeX)
 - Paste your Markdown and get instant conversion
-- Organized output folders with date-based naming
+ - Organized output folders with date plus snippet naming
 - Built on shared `markdown_utils.py` module
 
 ```bash
@@ -95,8 +95,8 @@ python3 -c "from markdown_utils import check_pandoc; check_pandoc(); print('✅ 
 
 ## 📁 Output Organization
 
-All tools create organized output folders:
-- **PDF/**: PDF files with date-based naming (e.g., `20250525.pdf`, `20250525-1.pdf`)
+- All tools create organized output folders:
+- **PDF/**: PDF files named with the date and first six words (e.g., `20250525HelloWorldThisIsMy.pdf`)
 - **DOCX/**: Word documents
 - **LaTeX/**: LaTeX source files and compiled PDFs
 

--- a/README_UNIFIED.md
+++ b/README_UNIFIED.md
@@ -81,7 +81,7 @@ For macOS users, desktop integration is available:
 4. **Get your converted file**:
    ```
    🔄 Converting...
-   ✅ PDF created: PDF/20250525.pdf
+   ✅ PDF created: PDF/20250525HelloWorldThisIsMy.pdf
    
    ============================================================
    Convert another file? (y/N): 
@@ -91,9 +91,9 @@ For macOS users, desktop integration is available:
 
 The tool automatically creates and organizes files into format-specific folders:
 
-- **PDF files**: `PDF/20250525.pdf`, `PDF/20250525-1.pdf`, etc.
-- **Word files**: `DOCX/20250525.docx`, `DOCX/20250525-1.docx`, etc.
-- **LaTeX files**: `LaTeX/20250525.tex`, `LaTeX/20250525.pdf`, etc.
+- **PDF files**: `PDF/20250525HelloWorldThisIsMy.pdf`, `PDF/20250525HelloWorldThisIsMy-1.pdf`, etc.
+- **Word files**: `DOCX/20250525HelloWorldThisIsMy.docx`, `DOCX/20250525HelloWorldThisIsMy-1.docx`, etc.
+- **LaTeX files**: `LaTeX/20250525HelloWorldThisIsMy.tex`, `LaTeX/20250525HelloWorldThisIsMy.pdf`, etc.
   - Includes compiled PDF and auxiliary files (.aux, .log)
 
 ### Auto-Open Output
@@ -125,9 +125,9 @@ behavior. On **macOS**, PDFs open in **Preview** and DOCX files open in
 ## Features in Detail
 
 ### Smart File Naming
-- Files are named with the current date (YYYYMMDD format)
+- Files include the date plus the first six words in CamelCase
 - Automatic increment suffix prevents overwrites
-- Example: `20250525.pdf`, `20250525-1.pdf`, `20250525-2.pdf`
+- Example: `20250525HelloWorldThisIsMy.pdf`, `20250525HelloWorldThisIsMy-1.pdf`
 
 ### Dependency Management
 - Checks for Pandoc on startup (required)
@@ -191,7 +191,7 @@ Enter/paste your Markdown text:
 [Ctrl-D]
 
 🔄 Converting...
-✅ DOCX created: DOCX/20250525.docx
+✅ DOCX created: DOCX/20250525HelloWorldThisIsMy.docx
 
 Convert another file? (y/N): n
 👋 Goodbye!

--- a/generate-config.py
+++ b/generate-config.py
@@ -26,7 +26,7 @@ def generate_config_file(filepath="markdown-converter.json"):
             "auto_open_output": config["global"]["auto_open_output"],
             "_auto_open_output_comment": "Automatically open converted files after conversion (set to false to disable)",
             "output_naming": config["global"]["output_naming"],
-            "_output_naming_comment": "Naming scheme: 'date' (YYYYMMDD), 'prompt' (ask user), 'custom' (not implemented)"
+            "_output_naming_comment": "Naming scheme: 'date' (YYYYMMDD + first words), 'prompt' (ask user), 'custom' (not implemented)"
         },
         
         "pdf": {

--- a/legacy/MarkdownToLatex/MarkdownToLatex.py
+++ b/legacy/MarkdownToLatex/MarkdownToLatex.py
@@ -27,7 +27,7 @@ def main():
     # Setup output
     output_dir = 'LaTeX'
     ensure_output_dir(output_dir)
-    output_tex = get_dated_filename(output_dir, 'tex')
+    output_tex = get_dated_filename(output_dir, 'tex', markdown_text)
 
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-s', '-f', 'markdown', '-t', 'latex', '-o', output_tex]

--- a/legacy/MarkdownToLatex/README.md
+++ b/legacy/MarkdownToLatex/README.md
@@ -34,7 +34,7 @@ Paste or type your Markdown into stdin, then end the input with EOF:
 
 Finish with Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows).
 
-After conversion, you will have both LaTeX and PDF files named with the current date in the `LaTeX/` folder.
+After conversion, you will have both LaTeX and PDF files named with the date and the first six words in the `LaTeX/` folder.
 
 ### File Mode
 
@@ -44,7 +44,7 @@ Pipe a Markdown file directly, then compile to PDF:
 cat mydoc.md | ./MarkdownToLatex.py
 ```
 
-Generated files: Files in `LaTeX/` folder named with current date (e.g. `LaTeX/20250525.tex`, or `LaTeX/20250525-1.tex`, etc.) and corresponding PDF.
+Generated files: Files in `LaTeX/` folder named with the date and first six words (e.g. `LaTeX/20250525HelloWorldThisIsMy.tex`, `LaTeX/20250525HelloWorldThisIsMy-1.tex`, etc.) and corresponding PDF.
 
 ## Example
 
@@ -56,8 +56,8 @@ Finish with Ctrl-D (Unix) or Ctrl-Z then Enter (Windows):
 
 This is *Markdown*.
 [Ctrl-D]
-LaTeX created: LaTeX/20250525.tex
-PDF created: LaTeX/20250525.pdf
+LaTeX created: LaTeX/20250525HelloWorldThisIsMy.tex
+PDF created: LaTeX/20250525HelloWorldThisIsMy.pdf
 ```
 ## macOS Launcher
 

--- a/legacy/MarkdownToPDF/MarkdownToPDF.py
+++ b/legacy/MarkdownToPDF/MarkdownToPDF.py
@@ -27,7 +27,7 @@ def main():
     # Setup output
     output_dir = 'PDF'
     ensure_output_dir(output_dir)
-    output_pdf = get_dated_filename(output_dir, 'pdf')
+    output_pdf = get_dated_filename(output_dir, 'pdf', markdown_text)
 
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-o', output_pdf]

--- a/legacy/MarkdownToPDF/README.md
+++ b/legacy/MarkdownToPDF/README.md
@@ -32,7 +32,7 @@ Step-by-step:
        ./MarkdownToPDF.py
 4. Paste or type your Markdown text.
 5. Press Ctrl-D (Unix/macOS) or Ctrl-Z then Enter (Windows) to finish input.
-6. The script creates a `PDF/` folder and writes a PDF named with the current date (e.g. `PDF/20250523.pdf`, or `PDF/20250523-1.pdf`, etc., if a file with the same name already exists).
+6. The script creates a `PDF/` folder and writes a PDF named with the date and the first six words (e.g. `PDF/20250523HelloWorldThisIsMy.pdf`, `PDF/20250523HelloWorldThisIsMy-1.pdf`, etc.).
 
 Example session:
     $ ./MarkdownToPDF.py
@@ -42,7 +42,7 @@ Example session:
 
     This is *Markdown*.
     [Ctrl-D]
-PDF created: PDF/20250523.pdf
+PDF created: PDF/20250523HelloWorldThisIsMy.pdf
 
 ## macOS Launcher
 

--- a/legacy/MarkdownToWord/MarkdownToWord.py
+++ b/legacy/MarkdownToWord/MarkdownToWord.py
@@ -27,7 +27,7 @@ def main():
     # Setup output
     output_dir = 'DOCX'
     ensure_output_dir(output_dir)
-    output_docx = get_dated_filename(output_dir, 'docx')
+    output_docx = get_dated_filename(output_dir, 'docx', markdown_text)
 
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-t', 'docx', '-o', output_docx]

--- a/legacy/MarkdownToWord/README.md
+++ b/legacy/MarkdownToWord/README.md
@@ -39,7 +39,7 @@ Pipe a Markdown file directly:
 cat mydoc.md | ./MarkdownToWord.py
 ```
 
-Generated files: Files in `DOCX/` folder named with current date (e.g. `DOCX/20250525.docx`, or `DOCX/20250525-1.docx`, etc.).
+Generated files: Files in `DOCX/` folder named with the date and the first six words (e.g. `DOCX/20250525HelloWorldThisIsMy.docx`, `DOCX/20250525HelloWorldThisIsMy-1.docx`, etc.).
 
 ## Example
 
@@ -51,7 +51,7 @@ Finish with Ctrl-D (Unix) or Ctrl-Z then Enter (Windows):
 
 This is *Markdown*.
 [Ctrl-D]
-DOCX created: DOCX/20250525.docx
+DOCX created: DOCX/20250525HelloWorldThisIsMy.docx
 ```
 ## macOS Launcher
 

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -11,12 +11,14 @@ import shutil
 import subprocess
 import datetime
 import json
+import re
 
 
 def get_unique_filename(basename):
     """
     Generate a filename that does not overwrite existing files.
-    E.g., for basename 'PDF/20250525.pdf', returns 'PDF/20250525.pdf' or 'PDF/20250525-1.pdf', etc.
+    E.g., for basename 'PDF/20250525HelloWorld.pdf', returns
+    'PDF/20250525HelloWorld.pdf' or 'PDF/20250525HelloWorld-1.pdf', etc.
     """
     base, ext = os.path.splitext(basename)
     filename = basename
@@ -66,10 +68,21 @@ def ensure_output_dir(output_dir):
     os.makedirs(output_dir, exist_ok=True)
 
 
-def get_dated_filename(output_dir, extension):
-    """Generate a date-based filename in the specified directory."""
+def get_snippet_slug(text, num_words=6):
+    """Return a CamelCase slug of the first `num_words` words in `text`."""
+    words = re.findall(r'[A-Za-z0-9]+', text)
+    snippet_words = words[:num_words]
+    return ''.join(word.capitalize() for word in snippet_words)
+
+
+def get_dated_filename(output_dir, extension, markdown_text=None):
+    """Generate a date-based filename, optionally appending a text snippet."""
     today_str = datetime.date.today().strftime('%Y%m%d')
-    default_file = os.path.join(output_dir, f'{today_str}.{extension}')
+
+    snippet = get_snippet_slug(markdown_text) if markdown_text else ''
+    base_name = f"{today_str}{snippet}"
+
+    default_file = os.path.join(output_dir, f"{base_name}.{extension}")
     return get_unique_filename(default_file)
 
 
@@ -79,7 +92,7 @@ def save_markdown_file(markdown_text, output_file_path):
     
     Args:
         markdown_text: String containing the markdown content
-        output_file_path: Path to the converted output file (e.g., 'PDF/20250525.pdf')
+        output_file_path: Path to the converted output file (e.g., 'PDF/20250525HelloWorld.pdf')
         
     Returns:
         str: Path to the saved markdown file


### PR DESCRIPTION
## Summary
- add helper to derive CamelCase snippet from text
- generate filenames using date plus snippet
- update convert scripts to pass text to new helper
- revise docs with new naming examples

## Testing
- `python3 -m py_compile MarkdownConverter.py markdown_utils.py generate-config.py legacy/MarkdownToPDF/MarkdownToPDF.py legacy/MarkdownToWord/MarkdownToWord.py legacy/MarkdownToLatex/MarkdownToLatex.py`


------
https://chatgpt.com/codex/tasks/task_e_683bc136745883279a1c9c0850c8fad1