### PR TITLE
Custom output filename option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Core functions used by all tools:
 #### File Management:
 - `get_unique_filename()`: Anti-overwrite protection with incremental suffixes
 - `ensure_output_dir()`: Creates output directories (PDF/, DOCX/, LaTeX/)
-- `get_dated_filename()`: Date + first six words in CamelCase with uniqueness
+- `get_dated_filename()`: Date plus a custom or snippet slug with uniqueness
 
 #### Dependency Management:
 - `check_pandoc()`: Validates pandoc availability, exits if missing

--- a/MarkdownConverter.py
+++ b/MarkdownConverter.py
@@ -55,14 +55,14 @@ def get_markdown_input_with_prompt():
 
     return get_markdown_input(prompt)
 
-def convert_to_pdf(markdown_text, config=None):
+def convert_to_pdf(markdown_text, config=None, slug=None):
     """Convert Markdown to PDF."""
     if config is None:
         config = load_config()
     
     output_dir = 'PDF'
     ensure_output_dir(output_dir)
-    output_pdf = get_dated_filename(output_dir, 'pdf', markdown_text)
+    output_pdf = get_dated_filename(output_dir, 'pdf', markdown_text, slug)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-o', output_pdf]
@@ -81,14 +81,14 @@ def convert_to_pdf(markdown_text, config=None):
 
     return output_pdf
 
-def convert_to_word(markdown_text, config=None):
+def convert_to_word(markdown_text, config=None, slug=None):
     """Convert Markdown to Word (DOCX)."""
     if config is None:
         config = load_config()
     
     output_dir = 'DOCX'
     ensure_output_dir(output_dir)
-    output_docx = get_dated_filename(output_dir, 'docx', markdown_text)
+    output_docx = get_dated_filename(output_dir, 'docx', markdown_text, slug)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-f', 'markdown', '-t', 'docx', '-o', output_docx]
@@ -107,14 +107,14 @@ def convert_to_word(markdown_text, config=None):
 
     return output_docx
 
-def convert_to_latex(markdown_text, has_pdflatex, config=None):
+def convert_to_latex(markdown_text, has_pdflatex, config=None, slug=None):
     """Convert Markdown to LaTeX and optionally compile to PDF."""
     if config is None:
         config = load_config()
     
     output_dir = 'LaTeX'
     ensure_output_dir(output_dir)
-    output_tex = get_dated_filename(output_dir, 'tex', markdown_text)
+    output_tex = get_dated_filename(output_dir, 'tex', markdown_text, slug)
     
     # Build pandoc arguments with configuration
     base_args = ['pandoc', '-s', '-f', 'markdown', '-t', 'latex', '-o', output_tex]
@@ -172,6 +172,12 @@ def main():
             print("👋 Goodbye!")
             sys.exit(0)
         
+        # Ask for optional file name to append after the date
+        slug_input = input(
+            "Enter a name to include in the output filename (optional): "
+        ).strip()
+        slug = slug_input if slug_input else None
+
         # Get markdown input
         markdown_text = get_markdown_input_with_prompt()
         
@@ -179,17 +185,17 @@ def main():
         
         try:
             if choice == '1':
-                output_file = convert_to_pdf(markdown_text, config)
+                output_file = convert_to_pdf(markdown_text, config, slug)
                 print(f"✅ PDF created: {output_file}")
             
             elif choice == '2':
-                output_file = convert_to_word(markdown_text, config)
+                output_file = convert_to_word(markdown_text, config, slug)
                 print(f"✅ DOCX created: {output_file}")
             
             elif choice == '3':
                 if not has_pdflatex and config['latex'].get('compile_pdf', True):
                     print("⚠️  Note: pdflatex not found. Only LaTeX file will be generated.")
-                tex_file, pdf_file = convert_to_latex(markdown_text, has_pdflatex, config)
+                tex_file, pdf_file = convert_to_latex(markdown_text, has_pdflatex, config, slug)
                 # Success messages are printed within the function
             
             print("\n" + "=" * 60)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A streamlined toolkit for converting Markdown to PDF, Word (DOCX), and LaTeX for
 **MarkdownConverter.py** - Interactive tool for all conversions:
 - Interactive menu to choose output format (PDF, Word, LaTeX)
 - Paste your Markdown and get instant conversion
- - Organized output folders with date plus snippet naming
+- Organized output folders with date plus your chosen name
 - Built on shared `markdown_utils.py` module
 
 ```bash
@@ -96,7 +96,7 @@ python3 -c "from markdown_utils import check_pandoc; check_pandoc(); print('✅ 
 ## 📁 Output Organization
 
 - All tools create organized output folders:
-- **PDF/**: PDF files named with the date and first six words (e.g., `20250525HelloWorldThisIsMy.pdf`)
+- **PDF/**: PDF files named with the date plus your chosen name (e.g., `20250525MyNotes.pdf`)
 - **DOCX/**: Word documents
 - **LaTeX/**: LaTeX source files and compiled PDFs
 

--- a/README_UNIFIED.md
+++ b/README_UNIFIED.md
@@ -124,10 +124,10 @@ behavior. On **macOS**, PDFs open in **Preview** and DOCX files open in
 
 ## Features in Detail
 
-### Smart File Naming
-- Files include the date plus the first six words in CamelCase
+-### Smart File Naming
+- Files include the date plus a name you provide
 - Automatic increment suffix prevents overwrites
-- Example: `20250525HelloWorldThisIsMy.pdf`, `20250525HelloWorldThisIsMy-1.pdf`
+- Example: `20250525MyNotes.pdf`, `20250525MyNotes-1.pdf`
 
 ### Dependency Management
 - Checks for Pandoc on startup (required)

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -75,12 +75,16 @@ def get_snippet_slug(text, num_words=6):
     return ''.join(word.capitalize() for word in snippet_words)
 
 
-def get_dated_filename(output_dir, extension, markdown_text=None):
-    """Generate a date-based filename, optionally appending a text snippet."""
+def get_dated_filename(output_dir, extension, markdown_text=None, custom_slug=None):
+    """Generate a date-based filename with an optional custom slug."""
     today_str = datetime.date.today().strftime('%Y%m%d')
 
-    snippet = get_snippet_slug(markdown_text) if markdown_text else ''
-    base_name = f"{today_str}{snippet}"
+    if custom_slug:
+        slug = get_snippet_slug(custom_slug)
+    else:
+        slug = get_snippet_slug(markdown_text) if markdown_text else ''
+
+    base_name = f"{today_str}{slug}"
 
     default_file = os.path.join(output_dir, f"{base_name}.{extension}")
     return get_unique_filename(default_file)


### PR DESCRIPTION
## Summary
- allow providing a custom name for generated output files
- prompt user for this name in the interactive converter
- document the new behavior in README and developer docs
- keep legacy behavior by falling back to snippet-based names

## Testing
- `python3 -m py_compile MarkdownConverter.py markdown_utils.py legacy/MarkdownToPDF/MarkdownToPDF.py legacy/MarkdownToWord/MarkdownToWord.py legacy/MarkdownToLatex/MarkdownToLatex.py`
- `python3 generate-config.py` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_683fe63e75788327b65b75dd070850eb